### PR TITLE
feat: 부스 전체 리스트 조회

### DIFF
--- a/src/main/java/knu/fest/knu/fest/domain/booth/controller/BoothController.java
+++ b/src/main/java/knu/fest/knu/fest/domain/booth/controller/BoothController.java
@@ -3,15 +3,15 @@ package knu.fest.knu.fest.domain.booth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import knu.fest.knu.fest.domain.booth.controller.dto.BoothCreateRequest;
-import knu.fest.knu.fest.domain.booth.controller.dto.BoothCreateResponse;
-import knu.fest.knu.fest.domain.booth.controller.dto.BoothDetailResponse;
-import knu.fest.knu.fest.domain.booth.controller.dto.BoothUpdateRequest;
+import knu.fest.knu.fest.domain.booth.controller.dto.*;
 import knu.fest.knu.fest.domain.booth.service.BoothService;
+import knu.fest.knu.fest.global.annotation.UserId;
 import knu.fest.knu.fest.global.common.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("api/v1")
@@ -72,5 +72,12 @@ public class BoothController {
         BoothDetailResponse response = boothService.getBooth(id);
 
         return ResponseDto.ok(response);
+    }
+
+    @GetMapping("")
+    public ResponseDto<List<BoothListResponse>> getAllBooths(@UserId Long userId) {
+        // 비로그인일 경우 userId는 null
+        List<BoothListResponse> responseList = boothService.getAllBooths(userId);
+        return ResponseDto.ok(responseList);
     }
 }

--- a/src/main/java/knu/fest/knu/fest/domain/booth/controller/dto/BoothListResponse.java
+++ b/src/main/java/knu/fest/knu/fest/domain/booth/controller/dto/BoothListResponse.java
@@ -7,15 +7,17 @@ public record BoothListResponse(
         String name,
         Integer boothNumber,
         Long waitingCount,
-        Long likeCount
+        Long likeCount,
+        boolean likedByMe // 로그인 사용자가 눌렀는지 여부
 ) {
-    public static BoothListResponse of(Booth booth) {
+    public static BoothListResponse of(Booth booth, boolean likedByMe) {
         return new BoothListResponse(
                 booth.getId(),
                 booth.getName(),
                 booth.getBoothNumber(),
                 booth.getWaitingCount(),
-                booth.getLikeCount()
+                booth.getLikeCount(),
+                likedByMe
         );
     }
 }

--- a/src/main/java/knu/fest/knu/fest/domain/booth/entity/Booth.java
+++ b/src/main/java/knu/fest/knu/fest/domain/booth/entity/Booth.java
@@ -66,11 +66,12 @@ public class Booth extends BaseEntity {
     }
 
     @Builder
-    public Booth(String name, String description, Integer boothNumber, Long likeCount) {
+    public Booth(String name, String description, Integer boothNumber, Long likeCount, Long waitingCount) {
         this.name = name;
         this.description = description;
         this.boothNumber = boothNumber;
         this.likeCount = likeCount;
+        this.waitingCount = waitingCount;
     }
 
     public void update(@NotBlank @Size(max = 120) String name, String description) {

--- a/src/test/java/knu/fest/knu/fest/domain/booth/service/BoothServiceTest.java
+++ b/src/test/java/knu/fest/knu/fest/domain/booth/service/BoothServiceTest.java
@@ -1,0 +1,105 @@
+package knu.fest.knu.fest.domain.booth.service;
+
+import knu.fest.knu.fest.domain.booth.controller.dto.BoothListResponse;
+import knu.fest.knu.fest.domain.booth.entity.Booth;
+import knu.fest.knu.fest.domain.booth.repository.BoothRepository;
+import knu.fest.knu.fest.domain.like.entity.Like;
+import knu.fest.knu.fest.domain.like.repository.LikeRepository;
+import knu.fest.knu.fest.domain.user.entity.User;
+import knu.fest.knu.fest.domain.user.entity.UserRole;
+import knu.fest.knu.fest.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class BoothServiceTest {
+
+    @Autowired
+    private BoothService boothService;
+
+    @Autowired
+    private BoothRepository boothRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    private User user;
+    private Booth booth1;
+    private Booth booth2;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.builder()
+                .email("test@example.com")
+                .password("password")
+                .nickname("tester")
+                .role(UserRole.USER)
+                .build());
+
+        booth1 = boothRepository.save(Booth.builder()
+                .name("Booth A")
+                .boothNumber(101)
+                .build());
+
+        booth2 = boothRepository.save(Booth.builder()
+                .name("Booth B")
+                .boothNumber(102)
+                .build());
+
+        // user가 booth2에 좋아요 누른 상태로 초기 설정
+        Like like = Like.builder()
+                .user(user)
+                .booth(booth2)
+                .build();
+        likeRepository.save(like); // save(user, booth) 형태로 좋아요 저장 메서드 가정
+    }
+
+    @Test
+    @DisplayName("부스 전체 조회 테스트 - 로그인 사용자")
+    void testGetAllBoothsForLoggedInUser() {
+        Long userId = user.getId();
+
+        List<BoothListResponse> responseList = boothService.getAllBooths(userId);
+
+        assertThat(responseList).hasSize(2);
+
+        BoothListResponse b1 = responseList.get(0);
+        assertThat(b1.id()).isEqualTo(booth1.getId());
+        assertThat(b1.name()).isEqualTo("Booth A");
+        assertThat(b1.likedByMe()).isFalse();
+
+        BoothListResponse b2 = responseList.get(1);
+        assertThat(b2.id()).isEqualTo(booth2.getId());
+        assertThat(b2.name()).isEqualTo("Booth B");
+        assertThat(b2.likedByMe()).isTrue(); // user가 좋아요 누른 상태
+    }
+
+    @Test
+    @DisplayName("부스 전체 조회 테스트 - 비로그인 사용자")
+    void testGetAllBoothsForAnonymousUser() {
+        Long userId = null; // 비로그인
+
+        List<BoothListResponse> responseList = boothService.getAllBooths(userId);
+
+        assertThat(responseList).hasSize(2);
+
+        responseList.forEach(booth -> {
+            assertThat(booth.likedByMe()).isFalse();
+        });
+
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!-- 해결한 문제를 지정하는 Issue Index에 연결해야 합니다. -->

- Resolves : #27 

## 작업 사항
<!-- 해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다. -->
- 부스 전체 조회 기능을 추가하였습니다.
- 부스 생성 시, entity에 like_count와 waiting_count를 0으로 초기화하였습니다.

## DB 변경 사항
<!-- 작업 사항이 DB에 영향이 있는 작업이라면 변경 사항을 적어야 합니다. -->

## 참고 사항
<!-- 기능을 만들기 위해 다른사람들이 참고해야할 사항을 적습니다. -->

## 변경된 API
<!-- 프론트엔드 개발자와 공유하기 위해 텔레그램을 통해 공유될 API 변동사항을 적습니다. ex) [API description](명세서 링크) -->
