### PR TITLE
refac: booth list sorted by waitingCount

### DIFF
--- a/src/main/java/knu/fest/knu/fest/domain/booth/service/BoothService.java
+++ b/src/main/java/knu/fest/knu/fest/domain/booth/service/BoothService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -82,6 +83,7 @@ public class BoothService {
         List<Booth> booths = boothRepository.findAll();
 
         return booths.stream()
+                .sorted(Comparator.comparingLong(Booth::getWaitingCount).reversed())
                 .map(booth -> {
                     boolean likedByMe = false;
                     if (userId != null) {


### PR DESCRIPTION
## 관련 이슈

- Resolves : 

## 작업 사항
부스 조회시 웨이팅은 큰순으로 정렬해서 전송


## DB 변경 사항

## 참고 사항


## 변경된 API

