### PR TITLE
refactor: 전체 부스 정렬로직에 좋아요 추가, 웨이팅 CD시 WaitingCount 증감 적용

### DIFF
--- a/src/main/java/knu/fest/knu/fest/domain/booth/entity/Booth.java
+++ b/src/main/java/knu/fest/knu/fest/domain/booth/entity/Booth.java
@@ -60,6 +60,17 @@ public class Booth extends BaseEntity {
     }
 */
 
+
+    public void addWaiting() {
+    this.waitingCount += 1;
+}
+
+    public void removeWaiting() {
+        if (this.waitingCount > 0) {
+            this.waitingCount -= 1;
+        }
+    }
+
     public void addLike() {
         this.likeCount += 1;
     }

--- a/src/main/java/knu/fest/knu/fest/domain/like/repository/LikeRepository.java
+++ b/src/main/java/knu/fest/knu/fest/domain/like/repository/LikeRepository.java
@@ -2,11 +2,18 @@ package knu.fest.knu.fest.domain.like.repository;
 
 import knu.fest.knu.fest.domain.like.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUserIdAndBoothId(Long userId, Long boothId);
 
     Optional<Like> findByUserIdAndBoothId(Long userId, Long boothId);
+
+    @Query("SELECT l.booth.id FROM Like l WHERE l.user.id = :userId")
+    List<Long> findAllBoothIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/knu/fest/knu/fest/domain/waiting/service/WaitingService.java
+++ b/src/main/java/knu/fest/knu/fest/domain/waiting/service/WaitingService.java
@@ -40,6 +40,10 @@ public class WaitingService {
 
         Waiting w = request.toEntity(booth);
         waitingRepository.save(w);
+
+        // WaitingCount + 1
+        booth.addWaiting();
+        boothRepository.save(booth);
         Long waitingId = w.getId();
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
@@ -64,6 +68,10 @@ public class WaitingService {
 
         waiting.cancel();
 
+        // WaitingCount -1
+        booth.removeWaiting();
+        boothRepository.save(booth);
+
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
@@ -85,6 +93,10 @@ public class WaitingService {
         Booth booth = boothRepository.findById(boothId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_BOOTH));
 
         waiting.complete();
+
+        // WaitingCount -1
+        booth.removeWaiting();
+        boothRepository.save(booth);
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override


### PR DESCRIPTION
## 관련 이슈
<!-- 해결한 문제를 지정하는 Issue Index에 연결해야 합니다. -->

- Resolves : #50 

## 작업 사항
<!-- 해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다. -->
- 부스 전체 조회시, 좋아요 누른 것을 가장 상단, 이후 웨이팅 수 내림차순으로 적용
- 웨이팅 생성/삭제 시, Boothes 테이블의 WaitingCount칼럼에 증감 적용

## DB 변경 사항
<!-- 작업 사항이 DB에 영향이 있는 작업이라면 변경 사항을 적어야 합니다. -->

## 참고 사항
<!-- 기능을 만들기 위해 다른사람들이 참고해야할 사항을 적습니다. -->

## 변경된 API
<!-- 프론트엔드 개발자와 공유하기 위해 텔레그램을 통해 공유될 API 변동사항을 적습니다. ex) [API description](명세서 링크) -->
