### PR TITLE
feat: 이벤트 응모 CRUD

### DIFF
--- a/src/main/java/knu/fest/knu/fest/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/controller/ApplicantController.java
@@ -1,0 +1,53 @@
+package knu.fest.knu.fest.domain.applicant.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import knu.fest.knu.fest.domain.applicant.controller.dto.ApplicantRequest;
+import knu.fest.knu.fest.domain.applicant.controller.dto.ApplicantResponse;
+import knu.fest.knu.fest.domain.applicant.controller.dto.ApplicantUpdateRequest;
+import knu.fest.knu.fest.domain.applicant.service.ApplicantService;
+import knu.fest.knu.fest.global.common.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/v1/applicant")
+@RequiredArgsConstructor
+@Tag(name = "Applicant API", description = "이벤트 응모자 생성/조회/수정/삭제 API")
+public class ApplicantController {
+
+    private final ApplicantService applicantService;
+
+    @PostMapping
+    public ResponseDto<String> createApplicant(
+            @Valid @RequestBody ApplicantRequest request
+    ){
+        String saved = applicantService.createApplicant(request);
+
+        return ResponseDto.created(saved);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ApplicantResponse>> getAllApplicants() {
+        return ResponseEntity.ok(applicantService.getAllApplicants());
+    }
+
+    @PutMapping
+    public ResponseDto<String> updateApplicant(@RequestBody ApplicantUpdateRequest request) {
+        String message = applicantService.updateApplicant(request);
+        return ResponseDto.ok(message);
+    }
+
+    @DeleteMapping
+    public ResponseDto<String> deleteApplicant(
+            @RequestParam Long studentNum
+    ) {
+        String message = applicantService.deleteApplicant(studentNum);
+        return ResponseDto.ok(message);
+    }
+
+
+}

--- a/src/main/java/knu/fest/knu/fest/domain/applicant/controller/dto/ApplicantRequest.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/controller/dto/ApplicantRequest.java
@@ -1,0 +1,20 @@
+package knu.fest.knu.fest.domain.applicant.controller.dto;
+
+import knu.fest.knu.fest.domain.applicant.entity.Applicant;
+import knu.fest.knu.fest.domain.applicant.entity.ApplicantRole;
+
+public record ApplicantRequest(
+        String name,
+        Long studentNum,
+        String department,
+        ApplicantRole role
+) {
+    public Applicant toEntity() {
+        return Applicant.builder()
+                .name(name)
+                .studentNum(studentNum)
+                .department(department)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/knu/fest/knu/fest/domain/applicant/controller/dto/ApplicantResponse.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/controller/dto/ApplicantResponse.java
@@ -1,0 +1,22 @@
+package knu.fest.knu.fest.domain.applicant.controller.dto;
+
+import knu.fest.knu.fest.domain.applicant.entity.Applicant;
+import knu.fest.knu.fest.domain.applicant.entity.ApplicantRole;
+
+public record ApplicantResponse(
+        Long id,
+        String name,
+        Long studentNum,
+        String department,
+        ApplicantRole role
+) {
+    public static ApplicantResponse from(Applicant applicant) {
+        return new ApplicantResponse(
+                applicant.getId(),
+                applicant.getName(),
+                applicant.getStudentNum(),
+                applicant.getDepartment(),
+                applicant.getRole()
+        );
+    }
+}

--- a/src/main/java/knu/fest/knu/fest/domain/applicant/controller/dto/ApplicantUpdateRequest.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/controller/dto/ApplicantUpdateRequest.java
@@ -1,0 +1,10 @@
+package knu.fest.knu.fest.domain.applicant.controller.dto;
+
+import knu.fest.knu.fest.domain.applicant.entity.ApplicantRole;
+
+public record ApplicantUpdateRequest(
+        String name,
+        Long studentNum,     // 수정 기준 학번 (기존 학번)
+        String department,
+        ApplicantRole role
+) { }

--- a/src/main/java/knu/fest/knu/fest/domain/applicant/entity/Applicant.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/entity/Applicant.java
@@ -1,0 +1,37 @@
+package knu.fest.knu.fest.domain.applicant.entity;
+
+import jakarta.persistence.*;
+import knu.fest.knu.fest.global.common.BaseEntity;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "applicants")
+public class Applicant extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private Long studentNum;
+
+    @Column(nullable = false)
+    private String department;
+
+    @Enumerated(EnumType.STRING)
+    private ApplicantRole role;
+
+    public void update(String name, Long studentNum, String department, ApplicantRole role) {
+        this.name = name;
+        this.studentNum = studentNum;
+        this.department = department;
+        this.role = role;
+    }
+
+}

--- a/src/main/java/knu/fest/knu/fest/domain/applicant/entity/ApplicantRole.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/entity/ApplicantRole.java
@@ -1,0 +1,6 @@
+package knu.fest.knu.fest.domain.applicant.entity;
+
+public enum ApplicantRole {
+    STAR,
+    UNIVERSE
+}

--- a/src/main/java/knu/fest/knu/fest/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/repository/ApplicantRepository.java
@@ -1,0 +1,15 @@
+package knu.fest.knu.fest.domain.applicant.repository;
+
+import knu.fest.knu.fest.domain.applicant.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.nio.channels.FileChannel;
+import java.util.Optional;
+
+public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+    // 학번으로 중복 여부 확인
+    Optional<Applicant> findByStudentNum(Long studentNum);
+
+    // 학과와 학번으로 특정 응모자 조회 (삭제용)
+    Optional<Applicant> findByDepartmentAndStudentNum(String department, Long studentNum);
+}

--- a/src/main/java/knu/fest/knu/fest/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/knu/fest/knu/fest/domain/applicant/service/ApplicantService.java
@@ -1,0 +1,66 @@
+package knu.fest.knu.fest.domain.applicant.service;
+
+import knu.fest.knu.fest.domain.applicant.controller.dto.ApplicantRequest;
+import knu.fest.knu.fest.domain.applicant.controller.dto.ApplicantResponse;
+import knu.fest.knu.fest.domain.applicant.controller.dto.ApplicantUpdateRequest;
+import knu.fest.knu.fest.domain.applicant.entity.Applicant;
+import knu.fest.knu.fest.domain.applicant.entity.ApplicantRole;
+import knu.fest.knu.fest.domain.applicant.repository.ApplicantRepository;
+import knu.fest.knu.fest.global.exception.CommonException;
+import knu.fest.knu.fest.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ApplicantService {
+
+    private final ApplicantRepository applicantRepository;
+
+    public String createApplicant(ApplicantRequest request) {
+        boolean exists = applicantRepository.findByStudentNum(request.studentNum()).isPresent();
+
+        if (exists) {
+            throw new CommonException(ErrorCode.ALREADY_EXIST_APPLICANT);
+        }
+        Applicant saved = applicantRepository.save(request.toEntity());
+
+        return "등록완료";
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApplicantResponse> getAllApplicants() {
+        return applicantRepository.findAll()
+                .stream()
+                .map(ApplicantResponse::from)
+                .toList();
+    }
+
+    public String updateApplicant(ApplicantUpdateRequest request) {
+        return applicantRepository.findByStudentNum(request.studentNum())
+                .map(applicant -> {
+                    applicant.update(
+                            request.name(),
+                            request.studentNum(),
+                            request.department(),
+                            request.role()
+                    );
+                    return "수정완료";
+                })
+                .orElse("해당 학번의 응모자를 찾을 수 없습니다.");
+    }
+
+
+    public String deleteApplicant(Long studentNum) {
+        return applicantRepository.findByStudentNum(studentNum)
+                .map(applicant -> {
+                    applicantRepository.delete(applicant);
+                    return "삭제완료";
+                })
+                .orElse("해당 학과/학번의 응모자를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/knu/fest/knu/fest/domain/like/controller/LikeController.java
+++ b/src/main/java/knu/fest/knu/fest/domain/like/controller/LikeController.java
@@ -31,7 +31,6 @@ public class LikeController {
             @UserId Long userId,
             @Valid @RequestBody LikeRequest request
     ) {
-        System.out.println("controller userId: " + userId);
         LikeResponse response = likeService.create(userId, request);
         return ResponseDto.created(response);
     }

--- a/src/main/java/knu/fest/knu/fest/global/constant/Constants.java
+++ b/src/main/java/knu/fest/knu/fest/global/constant/Constants.java
@@ -8,7 +8,8 @@ public class Constants {
     public static String USER_ROLE_CLAIM_NAME = "rol";
 
     public static List<String> ADMIN_AUTH_URLS = List.of(
-            "/api/v1/admin/notice/**"
+            "/api/v1/admin/notice/**",
+            "/api/v1/applicant"
     );
 
     public static List<String> BOOTH_ADMIN_AUTH_URLS = List.of(

--- a/src/main/java/knu/fest/knu/fest/global/exception/ErrorCode.java
+++ b/src/main/java/knu/fest/knu/fest/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     INVALID_ARGUMENT(40002, HttpStatus.BAD_REQUEST, "유효하지 않은 인자입니다."),
     ALREADY_HAVE_LIKE(40003, HttpStatus.BAD_REQUEST, "이미 좋아요를 눌렀습니다."),
     ALREADY_EXIST_BOOTH_NUMBER(40004, HttpStatus.BAD_REQUEST, "이미 존재하는 부스 번호입니다."),
+    ALREADY_EXIST_APPLICANT(40005, HttpStatus.BAD_REQUEST, "이미 존재하는 응모자입니다."),
 
     // Access Denied Error
     ACCESS_DENIED(40300, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,7 +15,7 @@ spring:
 
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: knufest
   profiles:
-    active: local
+    active: dev
     group:
       local:
         - local

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
 
         <!-- 로그 롤링 정책 설정 (필요한 경우 추가) -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/logs/app/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>logs/app/app.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory> <!-- 30일간 보관 -->
         </rollingPolicy>
 
@@ -28,7 +28,7 @@
 
         <!-- 로그 롤링 정책 설정 (필요한 경우 추가) -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/logs/user/user.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>logs/user/user.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory> <!-- 30일간 보관 -->
         </rollingPolicy>
 


### PR DESCRIPTION
## 관련 이슈
<!-- 해결한 문제를 지정하는 Issue Index에 연결해야 합니다. -->

- Resolves : #53 

## 작업 사항
<!-- 해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다. -->
- 이벤트 응모의 CRUD를 구현했습니다.
- 학번을 기준으로 중복검사를 실시하여, 중복이면 등록이 되지 않습니다.

## DB 변경 사항
<!-- 작업 사항이 DB에 영향이 있는 작업이라면 변경 사항을 적어야 합니다. -->
- applicants 테이블을 추가했습니다.

## 참고 사항
<!-- 기능을 만들기 위해 다른사람들이 참고해야할 사항을 적습니다. -->

## 변경된 API
<!-- 프론트엔드 개발자와 공유하기 위해 텔레그램을 통해 공유될 API 변동사항을 적습니다. ex) [API description](명세서 링크) -->
